### PR TITLE
Prepare for upgrade to Ember LTS 2.4

### DIFF
--- a/app/services/tracking-service.js
+++ b/app/services/tracking-service.js
@@ -2,7 +2,7 @@ import Ember from 'ember';
 import ENV from '../config/environment';
 var computed = Ember.computed;
 
-export default Ember.Object.extend({
+export default Ember.Service.extend({
   webPropertyId: Ember.get(ENV, 'googleAnalytics.webPropertyId'),
   dimensionMap: {
     company: 'dimension1',

--- a/package.json
+++ b/package.json
@@ -41,8 +41,8 @@
     "ember-disable-prototype-extensions": "^1.0.1",
     "ember-export-application-global": "^1.0.0",
     "express": "^4.8.5",
-    "glob": "^4.0.5"
-
+    "glob": "^4.0.5",
+    "lodash": "^4.11.0"
   },
   "keywords": [
     "ember-addon",
@@ -52,8 +52,5 @@
   ],
   "ember-addon": {
     "configPath": "tests/dummy/config"
-  },
-  "dependencies": {
-    "lodash-node": "^2.4.1"
   }
 }


### PR DESCRIPTION
Extend `Ember.Service` to fix `isServiceFactory` deprecation warning